### PR TITLE
Add va_end at the end of _print_selector function

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -110,6 +110,7 @@ int _print_selector(char *str, va_list list)
 		}
 		k++;
 	}
+	va_end(list);
 	return (count);
 }
 


### PR DESCRIPTION
This pull request contains the following:

- Add va_end at the end of _print_selector function

@SantiagoHerreG please check